### PR TITLE
Fix Security Vulnverabilities - Update Dependencies - Maven Plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 .idea
+target

--- a/pom.xml
+++ b/pom.xml
@@ -42,26 +42,26 @@
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-server</artifactId>
-      <version>9.2.6.v20141205</version>
+      <version>9.4.51.v20230217</version>
     </dependency>
 
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.2.3</version>
+      <version>2.14.2</version>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.2.3</version>
+      <version>2.14.2</version>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.2.3</version>
+      <version>2.14.2</version>
     </dependency>
 
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,12 @@
   <description>
     This is a library for subscribing/publishing to topics on ros through ros_bridge. It contains both high-level and low-level message control. The websocket server is implement with Jetty. 
   </description>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+  </properties>
 
    <url>https://github.com/h2r/java_rosbridge</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>2.2.1</version>
+        <version>3.2.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -103,7 +103,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.5.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -117,7 +117,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>1.7</version>
+        <version>3.3.0</version>
         <executions>
           <execution>
             <id>add-source</id>
@@ -137,7 +137,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.2-beta-4</version>
+        <version>3.5.0</version>
         <configuration>
           <descriptorRefs>
             <descriptorRef>jar-with-dependencies</descriptorRef>
@@ -156,7 +156,7 @@
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.3</version>
+        <version>1.6.13</version>
         <extensions>true</extensions>
         <configuration>
            <serverId>ossrh</serverId>
@@ -185,7 +185,7 @@
                 <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-gpg-plugin</artifactId>
-                  <version>1.5</version>
+                  <version>3.0.1</version>
                   <executions>
                     <execution>
                       <id>sign-artifacts</id>

--- a/src/ros/msgs/std_msgs/PrimitiveMsg.java
+++ b/src/ros/msgs/std_msgs/PrimitiveMsg.java
@@ -4,6 +4,7 @@ package ros.msgs.std_msgs;
  * A generic specified Java Bean for capturing many of the primitive data-type messages used by ROS in the std_msgs
  * package. The class has a single public data member called "data" that belongs to the specified primitive type.
  * @author James MacGlashan.
+ * @param <T> The primitive data type
  */
 public class PrimitiveMsg <T> {
 	public T data;


### PR DESCRIPTION
Hello and thank you for your work. 

These changes in principle update the dependencies versions and maven plugins. 
Some known vulnerabilities were being introduced previously, these are listed below.
This Pull Requests also sets JDK source/target to 17 and encoding to UTF8 for platform independent builds.
In addition, the `.idea` and `target` folders are also ignored.

Fixed vulnerabilities:
    https://github.com/advisories/GHSA-ghgj-3xqr-6jfm 7.5 Exposure of Sensitive Information to an Unauthorized Actor vulnerability pending CVSS allocation
    https://github.com/advisories/GHSA-vgg8-72f2-qm23 9.8 Integer Overflow or Wraparound vulnerability pending CVSS allocation
    https://github.com/advisories/GHSA-84q7-p226-4x5w 7.5 Improper Access Control vulnerability pending CVSS allocation
    https://github.com/advisories/GHSA-gwcr-j4wh-j3cq 5.3 Exposure of Sensitive Information to an Unauthorized Actor vulnerability pending CVSS allocation
    https://github.com/advisories/GHSA-cj7v-27pg-wf7q 2.7 Improper Input Validation vulnerability pending CVSS allocation
